### PR TITLE
Use text as the key for the (value, text) pairs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## Unreleased
+
+### Changed
+
+* Operations `add(value, text)` and `set(value, text)` have new behavior and now `text` has the role of key and thus must be unique. Similary the response from XHR must ensure that all `name` are unique. This was needed to support `<select>` elements where many `<option>` have the same value but different text.
+ 

--- a/coffee/selectorablium.coffee
+++ b/coffee/selectorablium.coffee
@@ -99,19 +99,19 @@ define [
 
     reset: -> @_insertOptionElement @config.default_value, @config.default_text
 
-    set: (key, value = null)->
+    set: (value, text = null)->
       ##TODO:
-      # if key and value
+      # if value and text
       ## UPDATE DATABASE
-      if value is null
-        value = @db.searchByKey key
-        return false if value is false
+      if text is null
+        text = @db.searchByValue value
+        return false if text is false
 
-      @_insertOptionElement key, value
+      @_insertOptionElement value, text
       @_hide()
       return true
 
-    add: (key, value)-> @db.add(key, value)
+    add: (value, text)-> @db.add(value, text)
 
     ## PRIVATE ##
     _createHtmlElements: ->
@@ -273,7 +273,7 @@ define [
       new_keys = {}
 
       for result in results
-        new_keys[result.id] = true
+        new_keys[result.name] = true
         new_item =
           id       : result.id
           name     : result.name
@@ -281,10 +281,10 @@ define [
           selected : false
           fresh    : !!xhr
 
-        if @indexed_structure[result.id]
-          new_item = $.extend(new_item, @indexed_structure[result.id])
+        if @indexed_structure[result.name]
+          new_item = $.extend(new_item, @indexed_structure[result.name])
 
-        @indexed_structure[result.id] = new_item
+        @indexed_structure[result.name] = new_item
         @structure.push new_item
 
       # Clean up @indexed_structure
@@ -321,7 +321,7 @@ define [
           class_name += ' new' if item.fresh is true
           class_name += ' selected' if item.selected is true
 
-          items_templates.push "<li><a href='#' class='#{class_name}' data-value='#{item.id}'>#{item.template}</a></li>"
+          items_templates.push "<li><a href='#' class='#{class_name}' data-value='#{item.id}' data-text='#{item.name}'>#{item.template}</a></li>"
           item.fresh    = false
 
       items_templates.join('\n')
@@ -383,7 +383,7 @@ define [
 
     _resetSelectedItem: ->
       return unless @selected_item
-      ref = @indexed_structure[@selected_item.data('value')]
+      ref = @indexed_structure[@selected_item.data('text')]
       ref and ref.selected = false
 
       @selected_item.removeClass('selected')
@@ -395,7 +395,7 @@ define [
       @_resetSelectedItem()
 
       @selected_item = $item.addClass('selected')
-      @indexed_structure[$item.data('value')].selected = true
+      @indexed_structure[$item.data('text')].selected = true
 
     _getNextItem: (direction)->
       count = @$result_items.length

--- a/coffee/storage_freak.coffee
+++ b/coffee/storage_freak.coffee
@@ -84,14 +84,17 @@ define [
         @_data = @_get @_data_key
         return new $.Deferred().resolve()
 
-    add: (key, value)->
-      return if @_data[key]
+    add: (value, text)->
+      return if @_data[text]
       new_data = {}
-      new_data[key] = value
+      new_data[text] = value
       @_data = $.extend {}, @_data, new_data
       @_updateDB @_data
 
-    searchByKey: (key)-> @_data[key] or false
+    searchByValue: (val) ->
+      for text, value of @_data
+        return text if value == val
+      return false
 
     ###*
      * The main API method.
@@ -142,7 +145,7 @@ define [
       query = @_createAccentIndependentQuery(query)
 
       re = @_createQueryRE(query, @config.search_type)
-      for id, name of @_data
+      for name, id of @_data
         results.push({id: id, name: name}) if match_func(re, name)
 
       @_resetSortingREs()
@@ -198,7 +201,7 @@ define [
 
     _parseResponseData: (json_data)->
       result = {}
-      result[item.id] = item.name for item in json_data
+      result[item.name] = item.id for item in json_data
       return result
 
     _updateDB: (data)->

--- a/spec/storagefreak_spec.coffee
+++ b/spec/storagefreak_spec.coffee
@@ -365,21 +365,21 @@ describe 'StorageFreak', ->
       @timestamp = @instance._get @instance._timestamp_key
 
     it 'expects key as first argument and value as second', ->
-      @instance.add('lala', 'koko')
+      @instance.add('koko', 'lala')
       expect(@instance._get @instance._data_key).to.eql
         koko: 'lala'
         koko2: 'lala2'
         lala: 'koko'
 
     it 'appends data to localStorage', ->
-      @instance.add('lala', 'koko')
+      @instance.add('koko', 'lala')
       expect(@instance._get @instance._data_key).to.eql
         koko: 'lala'
         koko2: 'lala2'
         lala: 'koko'
 
     it 'appends data to @_data', ->
-      @instance.add('lala', 'koko')
+      @instance.add('koko', 'lala')
       expect(@instance._data).to.eql
         koko: 'lala'
         koko2: 'lala2'
@@ -390,11 +390,11 @@ describe 'StorageFreak', ->
         expect(true).to.be.true
         done()
 
-      @instance.add('lala', 'koko')
+      @instance.add('koko', 'lala')
 
     context 'when key exists', ->
       beforeEach ->
-        @instance.add('koko', 'different_value')
+        @instance.add('different_value', 'koko')
 
       it 'does not update key with new value in localStorage', ->
         expect(@instance._get @instance._data_key).to.eql
@@ -408,18 +408,18 @@ describe 'StorageFreak', ->
 
 
 
-  describe 'searchByKey', ->
+  describe 'searchByValue', ->
     beforeEach ->
       @instance = @StorageFreak(@init_options)
       @instance._data = {
         koko: 'lala'
       }
 
-    it 'returns value for searched key', ->
-      expect(@instance.searchByKey('koko')).to.equal('lala')
+    it 'returns value for searched value', ->
+      expect(@instance.searchByValue('lala')).to.equal('koko')
 
     it 'returns false if nothing is found', ->
-      expect(@instance.searchByKey('lala')).to.equal(false)
+      expect(@instance.searchByValue('koko')).to.equal(false)
 
     it 'does not make an XHR', ->
       expect(@requests).to.have.length(0)
@@ -436,7 +436,7 @@ describe 'StorageFreak', ->
 
     it 'matches only infix data by default', (done)->
       @instance._data = {
-        add: 'addasjjjj'
+        addasjjjj: 'add'
         asd: 'asd'
         as: 'as'
       }
@@ -456,7 +456,7 @@ describe 'StorageFreak', ->
 
       it 'matches prefix', (done)->
         @instance._data = {
-          add: 'addas'
+          addas: 'add'
           asd: 'asd'
           as: 'as'
         }
@@ -486,9 +486,9 @@ describe 'StorageFreak', ->
 
     it 'matches accented characters ignoring their accent', (done)->
       @instance._data = {
-        as: 'λολο'
-        asd: 'λόλο'
-        add: 'λαλα'
+        λολο: 'as'
+        λόλο: 'asd'
+        λαλα: 'add'
       }
 
       @instance.on 'dbsearch_results', (data, query)->
@@ -529,13 +529,13 @@ describe 'StorageFreak', ->
 
     it 'sorts results by absolute matches, token matches, prefix matches', (done)->
       @instance._data =
-        k1: 'skyram'
-        k2: 'abraram'
-        k3: 'mr ram'
-        k4: 'babaoram'
-        k5: 'rambo'
-        k6: 'ram mania'
-        k7: 'ram'
+        skyram: 'k1'
+        abraram: 'k2'
+        'mr ram': 'k3'
+        babaoram: 'k4'
+        rambo: 'k5'
+        'ram mania': 'k6'
+        ram: 'k7'
 
       @instance.config.maxResultsNum = 7
 


### PR DESCRIPTION
Selectorablium acts as a wrapper for a select with value, text options.
The internals of the implementation use value as a unique key and this
forbids multiple texts with the same value which is a common scenario
in web pages. This commit changes the internals to use text as the key.
This way of course you can't have the same key text with different value
but this is a very rare case