### PR TITLE
Fix deprecated syntax of gradient property

### DIFF
--- a/scss/selectorablium.scss
+++ b/scss/selectorablium.scss
@@ -175,7 +175,7 @@
           background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #049cdb), color-stop(100%, #0064cd));
           background-image: -webkit-linear-gradient(top, #049cdb, #0064cd);
           background-image: -o-linear-gradient(top, #049cdb, #0064cd);
-          background-image: linear-gradient(top, #049cdb, #0064cd);
+          background-image: linear-gradient(to bottom, #049cdb, #0064cd);
           filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#049cdb', endColorstr='#0064cd', GradientType=0);
           text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
           margin: 0 -1px 0 -1px;


### PR DESCRIPTION
`top` is a deprecated property for `linear gradient` and needs to be updated to `to bottom`. More info: https://github.com/postcss/autoprefixer/issues/530